### PR TITLE
Add GitHub Actions workflow for deploying Gradio app to GitHub Pages

### DIFF
--- a/.github/workflows/deploy_gradio_app.yml
+++ b/.github/workflows/deploy_gradio_app.yml
@@ -1,0 +1,41 @@
+name: Deploy Gradio App to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Adjust this to your main branch name
+  workflow_dispatch:  # Allow manual triggering of the workflow
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-gradio:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out the code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Set up Python
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Step 3: Install dependencies
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # Step 4: Deploy Gradio app dynamically
+      - name: Deploy Gradio App
+        env:
+          API_KEY_1: ${{ secrets.OPENAI_API_KEY }}
+          API_KEY_2: ${{ TAVILY_API_KEY }}
+        run: |
+          git config --global user.email "akileshjayakumar88@gmail.com"
+          git config --global user.name "Akilesh Jayakumar"
+          python agent/app.py --server-name 0.0.0.0 --server-port 8000


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to deploy a Gradio application to GitHub Pages. The main changes include setting up the workflow to trigger on specific events, configuring the environment, and deploying the application.

Key changes:

* [`.github/workflows/deploy_gradio_app.yml`](diffhunk://#diff-a2d11efd69c855c4c0c9d1f558128d2c38ebb0faac770c0242765df5e4d0c41dR1-R41): Added a new workflow file to deploy the Gradio app on push to the main branch and manual dispatch. The workflow includes steps for checking out the code, setting up Python, installing dependencies, and deploying the app.